### PR TITLE
Improve error message for failed execute() commands

### DIFF
--- a/src/libmaus2/util/PosixExecute.cpp
+++ b/src/libmaus2/util/PosixExecute.cpp
@@ -899,7 +899,10 @@ int libmaus2::util::PosixExecute::execute(std::string const & command, std::stri
 		{
 			try
 			{
-				std::cerr << "libmaus2::util::PosixExecute::execute() failed: " << strerror(error) << std::endl;		
+				if ( error == 0 )
+					std::cerr << "libmaus2::util::PosixExecute::execute(): \"" << command << "\" exited with status " << returncode << std::endl;
+				else
+					std::cerr << "libmaus2::util::PosixExecute::execute() failed: " << strerror(error) << std::endl;
 			}
 			catch(...)
 			{
@@ -908,7 +911,10 @@ int libmaus2::util::PosixExecute::execute(std::string const & command, std::stri
 		else
 		{
 			libmaus2::exception::LibMausException lme;
-			lme.getStream() << "libmaus2::util::PosixExecute::execute() failed: " << strerror(error) << std::endl;
+			if ( error == 0 )
+				lme.getStream() << "libmaus2::util::PosixExecute::execute(): \"" << command << "\" exited with status " << returncode << std::endl;
+			else
+				lme.getStream() << "libmaus2::util::PosixExecute::execute() failed: " << strerror(error) << std::endl;
 			lme.finish();
 			throw lme;
 		}


### PR DESCRIPTION
Colleagues have been seeing messages of the form:

> libmaus2::util::PosixExecute::execute() failed: Success

Looking at this function, this appears to be because the command executed is exiting with a non-zero status, as opposed to the other paths in the function in which various system/C library calls fail and `error` gets set.

This adds a separate message, that includes the command that is failing so that we have a chance to track down the actual cause of these messages.
