### PR TITLE
Report the same stats from various mark duplicate programs.

### DIFF
--- a/src/libmaus2/bambam/BamStreamingMarkDuplicates.hpp
+++ b/src/libmaus2/bambam/BamStreamingMarkDuplicates.hpp
@@ -309,10 +309,13 @@ namespace libmaus2
 				uint64_t const thislib = algn.getLibraryId(header);
 				::libmaus2::bambam::DuplicationMetrics & met = metrics[thislib];
 				
-				if ( ! algn.isMapped() )
-					++met.unmapped;
-				else if ( (!algn.isPaired()) || algn.isMateUnmap() )
-					++met.unpaired;
+				if ( ! (algn.isSupplementary() || algn.isSecondary() || algn.isQCFail()) )
+				{
+				        if ( ! algn.isMapped() )
+					        ++met.unmapped;
+				    	else if ( (!algn.isPaired()) || algn.isMateUnmap() )
+					    	++met.unpaired;
+				}
 
 				uint64_t tagid = 0;
 

--- a/src/libmaus2/bambam/parallel/FragmentAlignmentBufferRewriteReadEndsWorkPackageDispatcher.hpp
+++ b/src/libmaus2/bambam/parallel/FragmentAlignmentBufferRewriteReadEndsWorkPackageDispatcher.hpp
@@ -150,7 +150,8 @@ namespace libmaus2
 
 							if ( 
 								(flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FSUPPLEMENTARY) == 0 &&
-								(flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FSECONDARY) == 0
+								(flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FSECONDARY) == 0 &&
+								(flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FQCFAIL) == 0
 							)
 							{
 								if ( flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FUNMAP )
@@ -414,6 +415,8 @@ namespace libmaus2
 											libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FSECONDARY
 											|
 											libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FSUPPLEMENTARY
+											|
+											libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FQCFAIL
 										)
 								);
 							if ( relfrag )
@@ -437,13 +440,13 @@ namespace libmaus2
 						if ( pfirst )
 						{
 							uint32_t const flags = libmaus2::bambam::BamAlignmentDecoderBase::getFlags(pfirst + sizeof(uint32_t));
-							if ( flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FUNMAP )
+							if ( flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FUNMAP || flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FQCFAIL)
 								pfirst = 0;
 						}
 						if ( psecond )
 						{
 							uint32_t const flags = libmaus2::bambam::BamAlignmentDecoderBase::getFlags(psecond + sizeof(uint32_t));
-							if ( flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FUNMAP )
+							if ( flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FUNMAP || flags & libmaus2::bambam::BamFlagBase::LIBMAUS2_BAMBAM_FQCFAIL)
 								psecond = 0;						
 						}
 						


### PR DESCRIPTION
bammarkduplicates2, bamstreamingmarkduplicates and bamsormadup all produce slightly different stat results.  I have changed code used by bamstreamingmarkduplicates and bamsormadup to match the results bammarkduplicates2 would give.
