### PR TITLE
Simplified lru sparse file opening..

### DIFF
--- a/src/libmaus2/lru/SparseLRUFileBunch.hpp
+++ b/src/libmaus2/lru/SparseLRUFileBunch.hpp
@@ -82,30 +82,15 @@ namespace libmaus2
 					COSmap.erase(ito);
 				}
 				
-				std::string const fn = getFileName(fileid);
-				
-				if ( libmaus2::aio::InputStreamFactoryContainer::tryOpen(fn) )
-				{
-					libmaus2::aio::InputOutputStream::shared_ptr_type ptr(libmaus2::aio::InputOutputStreamFactoryContainer::constructShared(fn,
-						std::ios_base::in | std::ios_base::out | std::ios_base::binary
-					));
-					
-					COSmap[fileid] = ptr;
-					
-					ptr->seekg(0,std::ios::end);
-				
-					return *ptr;
-				}
-				else
-				{
-					libmaus2::aio::InputOutputStream::shared_ptr_type ptr(libmaus2::aio::InputOutputStreamFactoryContainer::constructShared(fn,
-						std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc
-					));
-				
-					COSmap[fileid] = ptr;
-				
-					return *ptr;				
-				}
+				libmaus2::aio::InputOutputStream::shared_ptr_type ptr(libmaus2::aio::InputOutputStreamFactoryContainer::constructShared(getFileName(fileid),
+					std::ios_base::in | std::ios_base::out | std::ios_base::binary
+				));
+
+				COSmap[fileid] = ptr;
+
+				ptr->seekg(0,std::ios::end);
+
+				return *ptr;
 			}
 		};
 	}


### PR DESCRIPTION
While tracking down the odd PosixExecute messages displayed by bamstreamingmarkduplicates I found the code that caused the exceptions was being called from the SparseLRUFileBunch class.  The file existence check and the file opening decisions based on it seem unnecessary to me.  Of course, there may be some subtle file handling condition that I am not seeing but for  bamstreamingmarkduplicates the code changes do not make any difference. 
