### PR TITLE
Fix to prevent large temp files in bamsormadup.

### DIFF
--- a/src/libmaus2/bambam/BamIndexGenerator.hpp
+++ b/src/libmaus2/bambam/BamIndexGenerator.hpp
@@ -562,8 +562,8 @@ namespace libmaus2
 									
 									// linear chunk of last mapped position (or position if unmapped)
 									int64_t const thislinchunkid =
-										(algn.isMapped() ?((algn.getPos()+algn.getReferenceLength())-1) : algn.getPos()) >> 14;
-										
+										(algn.isMapped() ?((algn.getPos() + (int64_t)algn.getReferenceLength())-1) : algn.getPos()) >> 14;
+
 									// check if this alignment is in a different linear chunk than the previous one
 									if ( 
 										algn.isMapped() 


### PR DESCRIPTION
A rare combination of position and cigar string can lead to 1 being subtracted from 0 in uint64_t ending up with a large number.  A sizeable (multi Tb) temp file is then created while looping round to reach that number.
