### PR TITLE
Add an experimental iRODS uri handler.

### DIFF
--- a/src/libmaus2/irods/IRodsFileBase.cpp
+++ b/src/libmaus2/irods/IRodsFileBase.cpp
@@ -20,7 +20,6 @@
 
 libmaus2::irods::IRodsFileBase::IRodsFileBase() : fdvalid(false)
 {
-
 }
 
 libmaus2::irods::IRodsFileBase::~IRodsFileBase()
@@ -32,7 +31,7 @@ libmaus2::irods::IRodsFileBase::~IRodsFileBase()
 		memset (&closeHandle, 0, sizeof (closeHandle));
 		closeHandle.l1descInx = fd;
 		
-		int const status = rcDataObjClose(commProvider->getComm(), &closeHandle);
+		int const status = rcDataObjClose(comm, &closeHandle);
 		
 		if ( status < 0 )
 		{
@@ -71,7 +70,7 @@ uint64_t libmaus2::irods::IRodsFileBase::read(
 	readOutHandle.buf   = buffer;
 	readOutHandle.len   = len;
 	
-	long const status = rcDataObjRead(commProvider->getComm(), &readInHandle, &readOutHandle);
+	long const status = rcDataObjRead(comm, &readInHandle, &readOutHandle);
 	
 	if ( status < 0 )
 	{
@@ -107,12 +106,12 @@ uint64_t libmaus2::irods::IRodsFileBase::seek(
 	openedDataObjInp_t seekInput;
 	fileLseekOut_t* seekOutput = NULL;
 	int status = -1;
-	
+
 	memset(&seekInput, 0, sizeof(seekInput));
 	seekInput.l1descInx = fd;
 	seekInput.offset    = offset;
 	seekInput.whence    = whence;
-	if((status = rcDataObjLseek(commProvider->getComm(), &seekInput, &seekOutput)) < 0) 
+	if((status = rcDataObjLseek(comm, &seekInput, &seekOutput)) < 0) 
 	{
 		char * subname = 0;
 		char * name = rodsErrorName(status,&subname);

--- a/src/libmaus2/irods/IRodsFileBase.hpp
+++ b/src/libmaus2/irods/IRodsFileBase.hpp
@@ -44,7 +44,10 @@ namespace libmaus2
 
 			bool fdvalid;
 			long fd; /* file descriptor returned by rcDataObjCreate() */
-			libmaus2::irods::IRodsCommProvider::shared_ptr_type commProvider;
+			
+			#if defined(LIBMAUS2_HAVE_IRODS)
+			rcComm_t * comm;
+			#endif
 			
 			private:
 			IRodsFileBase();

--- a/src/libmaus2/irods/IRodsSystem.cpp
+++ b/src/libmaus2/irods/IRodsSystem.cpp
@@ -34,6 +34,7 @@ libmaus2::irods::IRodsSystem::shared_ptr_type libmaus2::irods::IRodsSystem::getD
 	return defaultIrodsSystem;
 }
 
+
 libmaus2::irods::IRodsFileBase::unique_ptr_type libmaus2::irods::IRodsSystem::openFile(
 	#if defined(LIBMAUS2_HAVE_IRODS)
 	IRodsSystem::shared_ptr_type irodsSystem, 
@@ -45,6 +46,9 @@ libmaus2::irods::IRodsFileBase::unique_ptr_type libmaus2::irods::IRodsSystem::op
 )
 {
 	#if defined(LIBMAUS2_HAVE_IRODS)
+	
+	std::string const processed_filename = irodsSystem->setComm(filename); 
+	
 	IRodsFileBase::unique_ptr_type tptr(new IRodsFileBase);
 	IRodsFileBase & file = *tptr;
 
@@ -55,9 +59,9 @@ libmaus2::irods::IRodsFileBase::unique_ptr_type libmaus2::irods::IRodsSystem::op
 	memset (&pathParseHandle, 0, sizeof (pathParseHandle));
 	
 	// copy filename
-	libmaus2::autoarray::AutoArray<char> filenameCopy(filename.size()+1,false);
-	std::copy(filename.begin(),filename.end(),filenameCopy.begin());
-	filenameCopy[filename.size()] = 0;
+	libmaus2::autoarray::AutoArray<char> filenameCopy(processed_filename.size()+1,false);
+	std::copy(processed_filename.begin(),processed_filename.end(),filenameCopy.begin());
+	filenameCopy[processed_filename.size()] = 0;
 	
 	// parse path
 	if ( (status = parseRodsPathStr(filenameCopy.begin(),&(irodsSystem->irodsEnvironment),pathParseHandle.objPath)) < 0 )
@@ -88,7 +92,7 @@ libmaus2::irods::IRodsFileBase::unique_ptr_type libmaus2::irods::IRodsSystem::op
 	}
 	
 	file.fd           = descriptor;
-	file.commProvider = irodsSystem;
+	file.comm         = irodsSystem->getComm();
 	file.fdvalid      = true;
 
 	return UNIQUE_PTR_MOVE(tptr);
@@ -98,7 +102,136 @@ libmaus2::irods::IRodsFileBase::unique_ptr_type libmaus2::irods::IRodsSystem::op
 	lme.finish();
 	throw lme;		
 	#endif
-}	
+}
+
+
+#if defined(LIBMAUS2_HAVE_IRODS)
+
+std::string libmaus2::irods::IRodsSystem::setComm(std::string const & filename)
+{
+	std::string host;
+	std::string zone;
+	std::string user;
+	int port;
+	
+	std::string file = parseIRodsURI(filename, host, zone, user, port); 	
+	
+	std::string search = host + ":" + std::to_string(port);
+	
+	if ( comms.find(search) != comms.end() ) 
+	{
+	    	comm = comms[search];
+	} 
+	else
+	{
+	    	// open connection to iRODS server
+	    
+	    	int status = -1;
+	    	rErrMsg_t errorMessage;
+	    	comm = rcConnect(
+		        const_cast<char *>(host.c_str()), 
+		    	port, 
+		    	const_cast<char *>(user.c_str()),
+		    	const_cast<char *>(zone.c_str()),
+		    	0, &errorMessage
+	    	);
+	    
+	    	// check if we were successful
+		if ( ! comm )
+		{
+			char * subname = 0;
+			char * name = rodsErrorName(errorMessage.status, &subname);
+
+			libmaus2::exception::LibMausException lme;
+			lme.getStream() << "IRodsSystem: failed to connect to iRODS via rcConnect(): "
+				<< name << " (" << subname << ")" << "(" << errorMessage.status << ")" << " " << errorMessage.msg << "\n";
+			lme.finish();
+			throw lme;
+		}
+
+		// perform login
+		if ( (status = clientLogin(comm)) < 0 )
+		{
+			char * subname = 0;
+			char * name = rodsErrorName(status, &subname);
+
+			libmaus2::exception::LibMausException lme;
+			lme.getStream() << "IRodsSystem: call clientLogin failed: " << status << " (" << name << ")\n";
+			lme.finish();
+			throw lme;		
+		}
+
+		// store the newly opened comm handle
+		comms[search] = comm;
+	}
+	
+	return file;
+}
+
+/*
+    Provisional scheme for an iRODS uri looks like this.
+    
+    irods://[irodsUserName%23irodsZone@][irodsHost][:irodsPort]/collection_path/data_object
+*/
+
+std::string libmaus2::irods::IRodsSystem::parseIRodsURI(std::string const & uri, 
+    	std::string & host, std::string & zone, std::string & user, int & port)
+{
+	// copy default connection info into local version    
+    	host = std::string(irodsEnvironment.rodsHost);
+	zone = std::string(irodsEnvironment.rodsZone);
+	user = std::string(irodsEnvironment.rodsUserName);
+        port = irodsEnvironment.rodsPort;
+	
+	// these should always be true if we have an auth section
+	std::size_t auth      = uri.find("//");
+	std::size_t tag_start = auth + std::string("//").length();
+	std::size_t port_end  = uri.find("/", tag_start);
+
+	if ( auth == std::string::npos || port_end == std::string::npos )
+	{
+	    	// nothing we can do with this so return untouched
+	    	return uri;
+	}
+
+	// look for the user name
+	std::size_t tag_end = uri.find("%23");
+
+	if ( tag_end != std::string::npos ) 
+	{
+    	    	user  = uri.substr(tag_start, tag_end - tag_start);
+	    	tag_start = tag_end + std::string("%23").length();
+	}
+
+	// look for zone
+	tag_end = uri.find("@");
+
+	if ( tag_end != std::string::npos ) 
+	{
+    	    	zone  = uri.substr(tag_start, tag_end - tag_start);
+	    	tag_start = tag_end + 1;
+	}
+
+	// now the host and port
+	tag_end = uri.find(":", auth);
+	std::size_t host_tag = tag_end + 1;
+
+	if ( tag_end != std::string::npos ) 
+	{
+    	    	host = uri.substr(tag_start, tag_end - tag_start);
+    	    	port = stoi(uri.substr(host_tag, port_end - host_tag));
+	} 
+	else 
+	{
+    	    	host = uri.substr(tag_start, port_end - tag_start);
+	}
+
+    	// return location of the data object
+    	return uri.substr(port_end);
+}
+#endif
+
+
 
 libmaus2::irods::IRodsSystem::IRodsSystem() 
   #if defined(LIBMAUS2_HAVE_IRODS)
@@ -119,43 +252,9 @@ libmaus2::irods::IRodsSystem::IRodsSystem()
 		throw lme;
 	}
 	
-	// open connection to iRODS server
-	rErrMsg_t errorMessage;
-	comm = rcConnect(
-		irodsEnvironment.rodsHost, 
-		irodsEnvironment.rodsPort, 
-		irodsEnvironment.rodsUserName,
-		irodsEnvironment.rodsZone,0,
-		&errorMessage
-	);
-	
-	// check if we were successful
-	if ( ! comm )
-	{
-		char * subname = 0;
-		char * name = rodsErrorName(errorMessage.status, &subname);
-		
-		libmaus2::exception::LibMausException lme;
-		lme.getStream() << "IRodsSystem: failed to connect to iRODS via rcConnect(): "
-			<< name << " (" << subname << ")" << "(" << errorMessage.status << ")" << " " << errorMessage.msg << "\n";
-		lme.finish();
-		throw lme;
-	}
-	
 	// reset SIG PIPE handler
 	prevpipesighandler = signal(SIGPIPE, SIG_DFL);
 
-	// perform login
-	if ( (status = clientLogin(comm)) < 0 )
-	{
-		char * subname = 0;
-		char * name = rodsErrorName(status, &subname);
-		
-		libmaus2::exception::LibMausException lme;
-		lme.getStream() << "IRodsSystem: call clientLogin failed: " << status << " (" << name << ")\n";
-		lme.finish();
-		throw lme;		
-	}
 	#else
 	libmaus2::exception::LibMausException lme;
 	lme.getStream() << "IRodsSystem: iRODS support is not present." << std::endl;
@@ -164,6 +263,7 @@ libmaus2::irods::IRodsSystem::IRodsSystem()
 	#endif
 }
 
+
 libmaus2::irods::IRodsSystem::~IRodsSystem()
 {
 	#if defined(LIBMAUS2_HAVE_IRODS)
@@ -171,6 +271,9 @@ libmaus2::irods::IRodsSystem::~IRodsSystem()
 		signal(SIGPIPE, prevpipesighandler);
 	
 	// close connection
-	rcDisconnect(comm);
+	for ( std::map<std::string, rcComm_t *>::iterator itr = comms.begin(); itr != comms.end(); ++itr ) 
+	{
+	    	rcDisconnect(itr->second);
+	}
 	#endif
 }

--- a/src/libmaus2/irods/IRodsSystem.cpp
+++ b/src/libmaus2/irods/IRodsSystem.cpp
@@ -114,9 +114,11 @@ std::string libmaus2::irods::IRodsSystem::setComm(std::string const & filename)
 	std::string user;
 	int port;
 	
-	std::string file = parseIRodsURI(filename, host, zone, user, port); 	
+	std::string file = parseIRodsURI(filename, host, zone, user, port);
+	std::stringstream port_to_string;
+	port_to_string << port;	
 	
-	std::string search = host + ":" + std::to_string(port);
+	std::string search = host + ":" + port_to_string.str();
 	
 	if ( comms.find(search) != comms.end() ) 
 	{
@@ -125,7 +127,7 @@ std::string libmaus2::irods::IRodsSystem::setComm(std::string const & filename)
 	else
 	{
 	    	// open connection to iRODS server
-	    
+
 	    	int status = -1;
 	    	rErrMsg_t errorMessage;
 	    	comm = rcConnect(
@@ -152,6 +154,9 @@ std::string libmaus2::irods::IRodsSystem::setComm(std::string const & filename)
 		// perform login
 		if ( (status = clientLogin(comm)) < 0 )
 		{
+		    	// clean up the lingering connection
+		    	rcDisconnect(comm);
+		
 			char * subname = 0;
 			char * name = rodsErrorName(status, &subname);
 

--- a/src/libmaus2/irods/IRodsSystem.hpp
+++ b/src/libmaus2/irods/IRodsSystem.hpp
@@ -51,6 +51,7 @@ namespace libmaus2
 			rodsEnv irodsEnvironment;
 			rcComm_t * comm;
 			sighandler_t prevpipesighandler;
+			std::map<std::string, rcComm_t *> comms; 
 			#endif
 
 			static IRodsFileBase::unique_ptr_type openFile(IRodsSystem::shared_ptr_type commProvider, std::string const & filename);
@@ -68,6 +69,13 @@ namespace libmaus2
 			{
 				return comm;
 			}
+			#endif
+			
+			#if defined(LIBMAUS2_HAVE_IRODS)
+			private:
+			    std::string setComm(std::string const & filename);
+    	    	    	    std::string parseIRodsURI(std::string const & uri, std::string & host, std::string & zone, 
+			    	    	    	      std::string & user, int & port);			
 			#endif
 		};		
 	}


### PR DESCRIPTION
This does not change current usage but adds the ability to target iRODS hosts.  The proposed uri scheme takes the form of irods://[irodsUserName%23irodsZone@][irodsHost][:irodsPort]/collection_path/data_object.  This is aimed to match a proposed (but unimplemented) iRODS scheme in htslib. 
