### PR TITLE
Added a seperate disconnect method to circumvent the iRODS 4.19 crash

### DIFF
--- a/src/libmaus2/irods/IRodsSystem.cpp
+++ b/src/libmaus2/irods/IRodsSystem.cpp
@@ -236,7 +236,18 @@ std::string libmaus2::irods::IRodsSystem::parseIRodsURI(std::string const & uri,
 }
 #endif
 
-
+void libmaus2::irods::IRodsSystem::disconnect(void) {
+	#if defined(LIBMAUS2_HAVE_IRODS)
+	// close all connections
+	for ( std::map<std::string, rcComm_t *>::iterator itr = comms.begin(); itr != comms.end(); ++itr )
+	{
+	    	rcDisconnect(itr->second);
+	}
+	
+	comms.clear();
+	#endif
+}
+    
 
 libmaus2::irods::IRodsSystem::IRodsSystem()
   #if defined(LIBMAUS2_HAVE_IRODS)
@@ -274,11 +285,7 @@ libmaus2::irods::IRodsSystem::~IRodsSystem()
 	#if defined(LIBMAUS2_HAVE_IRODS)
 	if ( prevpipesighandler != SIG_DFL )
 		signal(SIGPIPE, prevpipesighandler);
-
-	// close connection
-	for ( std::map<std::string, rcComm_t *>::iterator itr = comms.begin(); itr != comms.end(); ++itr )
-	{
-	    	rcDisconnect(itr->second);
-	}
+		
+	disconnect();
 	#endif
 }

--- a/src/libmaus2/irods/IRodsSystem.hpp
+++ b/src/libmaus2/irods/IRodsSystem.hpp
@@ -61,8 +61,11 @@ namespace libmaus2
 				IRodsFileBase::unique_ptr_type tptr(openFile(irodsSystem,filename));
 				return UNIQUE_PTR_MOVE(tptr);
 			}
+
 			IRodsSystem();
 			~IRodsSystem();
+
+    	    	    	void disconnect(void);
 
 			#if defined(LIBMAUS2_HAVE_IRODS)
 			virtual rcComm_t * getComm()


### PR DESCRIPTION
As of iRODS 4.19, any use of iRODS by libmaus2 crashes on program exit.  Both iRODS and libmaus2 use statically stored singleton objects that only go out of scope on program exit.  As objects are deallocated in reverse order of allocation, the iRODS objects that were created on rcConnect are destroyed before libmaus2 calls rcDisconnect leading to the disconnect code trying to access now invalid memory locations.  This change adds a disconnect method to be called by programs using libmaus2.  
