### PR TITLE
Added AdapterInfo copy constructor.

### DIFF
--- a/src/libmaus2/bambam/AdapterFilter.hpp
+++ b/src/libmaus2/bambam/AdapterFilter.hpp
@@ -100,6 +100,14 @@ namespace libmaus2
 					cname = name.c_str();
 					return *this;
 				}
+				
+				AdapterInfo(const AdapterInfo &O)
+				{
+					forward = O.forward;
+					reco = O.reco;
+					name = O.name;
+					cname = name.c_str();
+				}
 			};
 
 			// data not changed during operation


### PR DESCRIPTION
### The Problem
bamadapterfind crashing or producing corrupted data under certain versions of gcc.

### What is Happening
The list of adapters being stored in AdapterFilter is corrupted under gcc 6.2 and 5.4 (with the std=gnu++0x option set) but is fine in gcc 4.9.2 and 5.4 (without the gnu++0x being set).  This seems to be down to the change in how strings are stored in gcc.  During gcc 5 strings have moved from a Copy-On-Write (COW) implementation to a Small-String-Optimisation (SSO) [implementation](https://gcc.gnu.org/ml/gcc-patches/2014-11/msg01785.html).

AdapterInfo stores the string _name_ and a pointer to its C style string _cname_ which is set up when the class is instantiated.  The method **loadAdapterInfo** populates a temporary AdapterInfo object with data then pushes it onto a vector for later use.  This copying of objects leaves the vector AdapterInfo _cname_ pointing to the now deleted _name_ in the temporary AdapterInfo.

Under COW this did not matter as the unchanged string was stored in the same memory location at all times.  Under SSO _cname_ points to a now reallocated memory location leading to all sorts of randomness.

### The Solution
Add a copy constructor to make sure _cname_ points to its own copy of _name_.